### PR TITLE
Fix the remainint typing errors

### DIFF
--- a/calc.py
+++ b/calc.py
@@ -1,11 +1,11 @@
 from decimal import Decimal
-from typing import Iterable, Union
+from typing import List, Iterable, Union
 
 from mytypes import Arg, ArgError
 
 
 def calc(args: Iterable[Arg]) -> Union[Decimal]:
-    stack = []
+    stack: List[Decimal] = []
     for arg in args:
 
         def check_stack_len(num_args):

--- a/parse_exp.py
+++ b/parse_exp.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
+from typing import cast
 
-from mytypes import ArgList, ParseError
+from mytypes import ArgList, ParseError, Operator
 
 S_INITIAL = 0
 S_NUM_INT_DIGIT = 1
@@ -12,7 +13,7 @@ S_NUM_EXP_DIGIT = 6
 
 
 def parse_exp(s: str) -> ArgList:
-    args = []
+    args: ArgList = []
     state = S_INITIAL
     start = 0
     for i, c in enumerate(s + "\0"):
@@ -43,7 +44,7 @@ def parse_exp(s: str) -> ArgList:
 
             if is_operator:
                 state = S_INITIAL
-                args.append(s[i])
+                args.append(cast(Operator, s[i]))
                 continue
 
             raise ParseError(error_message())
@@ -61,7 +62,7 @@ def parse_exp(s: str) -> ArgList:
             if is_operator:
                 state = S_INITIAL
                 args.append(Decimal(s[start:i]))
-                args.append(s[i])
+                args.append(cast(Operator, s[i]))
                 continue
 
             if is_dot:
@@ -94,7 +95,7 @@ def parse_exp(s: str) -> ArgList:
             if is_operator:
                 state = S_INITIAL
                 args.append(Decimal(s[start:i]))
-                args.append(s[i])
+                args.append(cast(Operator, s[i]))
                 continue
 
             if is_exp:
@@ -134,7 +135,7 @@ def parse_exp(s: str) -> ArgList:
             if is_operator:
                 state = S_INITIAL
                 args.append(Decimal(s[start:i]))
-                args.append(s[i])
+                args.append(cast(Operator, s[i]))
                 continue
 
             raise ParseError(error_message())


### PR DESCRIPTION
Let's please mypy.

There is a problem where we try to assign an arbitrary string to a variable that expects a union of string literals. In other words, we try to assign a super-type to where a sub-type is expected.

```python
s: str = "+"
op: Operator = s; # <- type error here, `Operator` is a subtype of `str`
```

But we know for sure that these strings are indeed from the set of operator strings, so it causes no harm to use the type cast function [`cast`](https://mypy.readthedocs.io/en/stable/casts.html) -- 

```python
s: str = "+"
op: Operator = cast(Operator, s); # <- force `s` to be of type `Operator`
```
